### PR TITLE
Support spaces in directory names

### DIFF
--- a/functions/autojump-list-dirs.fish
+++ b/functions/autojump-list-dirs.fish
@@ -1,3 +1,3 @@
 function autojump-list-dirs
-  autojump -s | head -n -7 | sort -n | tac | awk '{print $2}'
+  autojump -s | head -n -7 | sort -n | tac | awk  '{$1=""; print $0}' | awk '{$1=$1};1'
 end


### PR DESCRIPTION
If directory had a space in its name e.g. "my folder/" the
fzf got a line "my" with rest of the name clipped off.
The reason for this was the awk command.

Added also another awk command to strip trailing spaces
to make this work.