### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -4,6 +4,6 @@ set -q autojump_fish; or set -g autojump_fish ~/.autojump/share/autojump/autojum
 if test -f $autojump_fish
   . $autojump_fish
 end
-if not which autojump >/dev/null ^/dev/null
+if not which autojump >/dev/null 2>/dev/null
   echo 'Autojump is not installed. Please install it first from https://github.com/wting/autojump#installation' >&2
 end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
